### PR TITLE
ci: add macOS and Windows to test-lint-build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
       contents: read
       packages: read
 
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Expands CI testing to run on Ubuntu, macOS, and Windows to ensure cross-platform compatibility of the build process.

🤖 Generated with [Claude Code](https://claude.ai/code)