### PR TITLE
chore: bump pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "top-github-dependents-by-stars": "catalog:",
     "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,13 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
 
+allowBuilds:
+  "@parcel/watcher": true
+  "@tailwindcss/oxide": true
+  esbuild: true
+
 onlyBuiltDependencies:
+  - "@parcel/watcher"
   - "@tailwindcss/oxide"
   - esbuild
 overrides:


### PR DESCRIPTION
Bumps the repo-root `packageManager` pin to `pnpm@11.1.2`.

Only the root `package.json` `packageManager` field is changed.