### PR TITLE
fix: prevent empty Vite 8 stats from breaking the build

### DIFF
--- a/apps/dashboard/src/components/vite/BuildTimeChart.tsx
+++ b/apps/dashboard/src/components/vite/BuildTimeChart.tsx
@@ -11,7 +11,7 @@ import {
   YAxis,
 } from "recharts";
 import * as semver from "semver";
-import viteStats from "../../../../../data/vite-version-stats.json";
+import { viteStats } from "../../data/viteStats";
 
 const buildTimeData = viteStats
   .map((stat) => ({

--- a/apps/dashboard/src/components/vite/BundleSizeChart.tsx
+++ b/apps/dashboard/src/components/vite/BundleSizeChart.tsx
@@ -12,7 +12,7 @@ import {
   YAxis,
 } from "recharts";
 import * as semver from "semver";
-import viteStats from "../../../../../data/vite-version-stats.json";
+import { viteStats } from "../../data/viteStats";
 
 const sortedViteStats = [...viteStats].toSorted((a, b) => semver.compare(a.version, b.version));
 

--- a/apps/dashboard/src/components/vite/StatsCards.tsx
+++ b/apps/dashboard/src/components/vite/StatsCards.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { formatNumberWithCommas } from "@vibe/utils";
-import viteStats from "../../../../../data/vite-version-stats.json";
+import { viteStats } from "../../data/viteStats";
 
 export function StatsCards() {
   const stats = useMemo(() => {

--- a/apps/dashboard/src/data/viteStats.ts
+++ b/apps/dashboard/src/data/viteStats.ts
@@ -1,0 +1,21 @@
+import rawViteStats from "../../../../data/vite-version-stats.json";
+
+export interface ViteStatFile {
+  path: string;
+  size: number;
+  type: string;
+}
+
+export interface ViteStat {
+  version: string;
+  timestamp: string;
+  publicationDate: string;
+  files: ViteStatFile[];
+  totalSize: number;
+  buildTime: number;
+}
+
+// Typed view of the generated stats. The underlying JSON can be an empty array
+// (e.g. before any stable Vite 8 release exists), which would otherwise be
+// inferred as `never[]` and break every property access downstream.
+export const viteStats = rawViteStats as ViteStat[];

--- a/apps/dashboard/src/pages/ViteStatsPage.tsx
+++ b/apps/dashboard/src/pages/ViteStatsPage.tsx
@@ -2,7 +2,7 @@ import { PageHeader } from "@vibe/shared";
 import { Badge } from "@vibe/ui";
 import { BarChart3, Clock, Package, TrendingUp } from "lucide-react";
 import { useState } from "react";
-import viteStatsData from "../../../../data/vite-version-stats.json";
+import { viteStats as viteStatsData } from "../data/viteStats";
 import { PageContainer } from "../components/layout/PageContainer";
 import ViteStats from "../ViteStats";
 

--- a/tools/override-vite.mjs
+++ b/tools/override-vite.mjs
@@ -345,9 +345,15 @@ async function collectAllVersionStats() {
     console.log("\n🔄 Restoring original package.json...");
     writeFileSync(DASHBOARD_PACKAGE_PATH, originalPackageJson);
 
-    // Save results
-    console.log(`\n💾 Saving results to ${STATS_OUTPUT_PATH}...`);
-    writeFileSync(STATS_OUTPUT_PATH, JSON.stringify(allStats, null, 2));
+    // Save results. Skip writing an empty dataset (e.g. when no stable Vite 8
+    // release exists yet) so we don't clobber the existing tracked stats and
+    // break the type-checked dashboard build.
+    if (allStats.length === 0) {
+      console.log(`\n⏭️  No stats collected — leaving ${STATS_OUTPUT_PATH} unchanged.`);
+    } else {
+      console.log(`\n💾 Saving results to ${STATS_OUTPUT_PATH}...`);
+      writeFileSync(STATS_OUTPUT_PATH, JSON.stringify(allStats, null, 2));
+    }
 
     console.log("\n==================== ANALYSIS COMPLETE ====================");
     console.log(`📊 Analysis Summary:`);


### PR DESCRIPTION
## Problem

The `Update Vite Stats` workflow ([failing run](https://github.com/voidzero-dev/vibe-dashboard/actions/runs/27080764637/job/79926065294)) runs `vp run generate` → `vp check --fix`. Since commit bf33f4a, `tools/override-vite.mjs` targets **stable Vite 8 releases** (`/^8\.\d+\.\d+$/`). No stable Vite 8 exists on npm yet, so `generate` writes an empty `[]` to `data/vite-version-stats.json`. With an empty array, TypeScript infers the JSON import as `never[]`, so every `stat.version` / `stat.buildTime` access fails (`Property 'X' does not exist on type 'never'`) and `vp check` errors out.

## Fix

- Add typed wrapper `apps/dashboard/src/data/viteStats.ts` that casts the JSON to `ViteStat[]`, so empty data type-checks instead of collapsing to `never[]`.
- Repoint all four importers (`BuildTimeChart`, `BundleSizeChart`, `StatsCards`, `ViteStatsPage`) at the typed module.
- Skip writing the stats file when no versions are collected, so existing tracked data isn't clobbered until Vite 8 ships. Picks up Vite 8 automatically once released.

Verified `vp check` and `vp run build` pass, including a simulated empty-data (`[]`) run.