### PR TITLE
fix(ci): stop recursive Vite stats updates

### DIFF
--- a/.github/workflows/update-vite-stats.yml
+++ b/.github/workflows/update-vite-stats.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - data/vite-version-stats.json
 
 permissions: {}
 


### PR DESCRIPTION
Ignore stats-only pushes in the Vite stats updater so auto-merged generated data cannot retrigger another update.

Validated with `vp check`, `vp test run`, and `vp run build`.